### PR TITLE
Update PyTorch to latest supported version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 librosa==0.5.1
 matplotlib==2.1.0
 natsort==5.1.0
-torch==0.2.0.post3
+torch==0.3.1


### PR DESCRIPTION
PyTorch version `0.2.0.post3` is no longer available using `pip install`. I've changed the requirements to a version that seems to work with SampleRNN.